### PR TITLE
FST-24: Adds terraform Code For Spinning Up An EKS Cluster

### DIFF
--- a/dev/af-south-1/app_variables.tfvars
+++ b/dev/af-south-1/app_variables.tfvars
@@ -1,1 +1,2 @@
 app_name = "fake-st"
+cluster_name = "fake-st-eks"

--- a/dev/af-south-1/eks/cluster/terragrunt.hcl
+++ b/dev/af-south-1/eks/cluster/terragrunt.hcl
@@ -1,0 +1,73 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_parent_terragrunt_dir()}/tf-modules/eks///"
+}
+
+inputs = {
+  cluster_name            = "fake-st-eks" # var.cluster_name
+  cluster_version         = "1.30"
+  instance_types          = ["t3.medium"]
+  scaling_desired_size    = 2
+  scaling_max_size        = 2
+  scaling_min_size        = 1
+
+  vpc_id                  = dependency.vpc.outputs.vpc_id
+  private_subnet_ids      = dependency.subnet.outputs.public_subnet_ids
+  public_subnet_ids       = dependency.subnet.outputs.private_subnet_ids
+  sg_id                   = dependency.security_group.outputs.sg_id
+  public_access_cidrs     = dependency.subnet.outputs.public_subnet_cidrs
+
+  eks_cluster_role_arn    = dependency.roles.outputs.eks_cluster_role_arn
+  eks_node_group_role_arn = dependency.roles.outputs.eks_node_group_role_arn
+}
+
+
+dependency "vpc" {
+  config_path = "../../vpc"
+  mock_outputs_allowed_terraform_commands = ["validate,plan"]
+  mock_outputs = {
+    vpc_id = "fake-vpc-id"
+    igw_id = "fake-igw-id"
+    ipv4_cidr_block = "fake-ipv4-cidr-block"
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+# subnet is a dependenct of vpc, making vpc a 'grand-dependency', all that will be sorted though by the dependency graph
+dependency "subnet" {
+  config_path = "../../subnet"
+  mock_outputs_allowed_terraform_commands = ["validate,plan"]
+  mock_outputs = {
+    private_subnet_ids = ["fake-private-subnet-id"]
+    public_subnet_ids = ["fake-public-subnet-id"]
+    private_route_table_ids = ["fake-private-rt-id"]
+    public_route_table_ids = ["fake-public-rt-id"]
+    public_subnet_cidrs = ["10.1.0.0/24"]
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+dependency "security_group" {
+  config_path = "../security_group"
+  mock_outputs_allowed_terraform_commands = ["validate,plan"]
+  mock_outputs = {
+    sg_id = "fake-sg-id"
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+
+dependency "roles" {
+  config_path = "../../role/eks"
+  mock_outputs_allowed_terraform_commands = ["validate,plan"]
+  mock_outputs = {
+    eks_cluster_role_id = "fake-id"
+    eks_cluster_role_arn = "arn:aws:iam::fake:role/fake-st-eks-eks-cluster-role"
+    eks_node_group_role_id = "fake-id"
+    eks_node_group_role_arn = "arn:aws:iam::fake:role/fake-st-eks-eks-node-group-role"
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}

--- a/dev/af-south-1/eks/security_group/terragrunt.hcl
+++ b/dev/af-south-1/eks/security_group/terragrunt.hcl
@@ -1,0 +1,22 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_parent_terragrunt_dir()}/tf-modules/security_group/eks_default///"
+}
+
+inputs = {
+  vpc_id = dependency.vpc.outputs.vpc_id
+}
+
+dependency "vpc" {
+  config_path = "../../vpc"
+  mock_outputs_allowed_terraform_commands = ["validate,plan"]
+  mock_outputs = {
+    vpc_id = "fake-vpc-id"
+    igw_id = "fake-igw-id"
+    ipv4_cidr_block = "fake-ipv4-cidr-block"
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}

--- a/dev/af-south-1/regional_variables.tfvars
+++ b/dev/af-south-1/regional_variables.tfvars
@@ -1,2 +1,2 @@
 aws_region = "af-south-1"
-availability_zones = ["af-south-1a"] # "af-south-1a", "af-south-1b", "af-south-1c"
+availability_zones = ["af-south-1a","af-south-1b"] # "af-south-1a", "af-south-1b", "af-south-1c"

--- a/dev/af-south-1/role/eks/terragrunt.hcl
+++ b/dev/af-south-1/role/eks/terragrunt.hcl
@@ -1,0 +1,7 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "${get_parent_terragrunt_dir()}/tf-modules/roles/eks///"
+}

--- a/dev/af-south-1/vpc/terragrunt.hcl
+++ b/dev/af-south-1/vpc/terragrunt.hcl
@@ -5,3 +5,8 @@ include {
 terraform {
   source = "${get_parent_terragrunt_dir()}/tf-modules/vpc///"
 }
+
+
+inputs = {
+  ipv4_primary_cidr_block   = "10.1.0.0/24"
+}

--- a/dev/global_variables.tfvars
+++ b/dev/global_variables.tfvars
@@ -1,0 +1,6 @@
+namespace = "fake-st"
+stage = "dev"
+parent_zone = "fake-st.com"
+
+ssh_public_key_path = "path"
+ssh_public_key_file = "key.pub"

--- a/dev/global_variables.tfvars
+++ b/dev/global_variables.tfvars
@@ -1,6 +1,0 @@
-namespace = "fake-st"
-stage = "dev"
-parent_zone = "fake-st.com"
-
-ssh_public_key_path = "path"
-ssh_public_key_file = "key.pub"

--- a/tf-modules/eks/main.tf
+++ b/tf-modules/eks/main.tf
@@ -1,0 +1,41 @@
+# Create EKS Cluster
+resource "aws_eks_cluster" "eks_cluster" {
+  name     = var.cluster_name
+  version  = var.cluster_version
+  role_arn = var.eks_cluster_role_arn
+
+  vpc_config { # Configure EKS with vpc and network settings 
+    subnet_ids              = flatten([var.public_subnet_ids[*], var.private_subnet_ids[*]])
+    security_group_ids      = ["${var.sg_id}"]
+    endpoint_public_access  = var.endpoint_public_access
+    endpoint_private_access = var.endpoint_private_access
+    # public_access_cidrs     = var.public_access_cidrs 
+    # Above fails with error InvalidParameterException: The following CIDRs are not allowed in publicAccessCidrs: [10.1.0.128/27, 10.1.0.96/27]
+  }
+
+  tags = {
+    namespace = var.namespace
+    stage     = var.stage
+  }
+}
+
+# Create EKS Node Groups
+resource "aws_eks_node_group" "worker-node-group" {
+  cluster_name    = aws_eks_cluster.eks_cluster.name
+  node_group_name = "${var.cluster_name}-node-group"
+  node_role_arn   = var.eks_node_group_role_arn
+  subnet_ids      = var.private_subnet_ids
+  instance_types  = var.instance_types
+
+  scaling_config {
+    desired_size = var.scaling_desired_size
+    max_size     = var.scaling_max_size
+    min_size     = var.scaling_min_size
+  }
+
+  tags = {
+    name      = "${var.cluster_name}-node-group"
+    namespace = var.namespace
+    stage     = var.stage
+  }
+}

--- a/tf-modules/eks/output.tf
+++ b/tf-modules/eks/output.tf
@@ -1,0 +1,9 @@
+output "cluster_name" {
+  description = "EKS Cluster Name"
+  value       = aws_eks_cluster.eks_cluster.name
+}
+
+output "cluster_endpoint" {
+  description = "Endpoint for EKS control plane"
+  value       = aws_eks_cluster.eks_cluster.endpoint
+}

--- a/tf-modules/eks/variables.tf
+++ b/tf-modules/eks/variables.tf
@@ -1,0 +1,89 @@
+# Application
+variable "app_name" {
+  type        = string
+  description = "App Name"
+}
+variable "namespace" {
+  type        = string
+  description = "Namespace"
+}
+variable "stage" {
+  type        = string
+  description = "Stage"
+}
+
+# Cluster
+variable "cluster_name" {
+  type        = string
+  description = "Name Of Cluster"
+}
+variable "cluster_version" {
+  type        = string
+  description = "Version Of The Cluster"
+}
+variable "instance_types" {
+  type        = set(string)
+  description = "Set of instance types associated with the EKS worker Node Group."
+}
+
+variable "scaling_desired_size" {
+  type        = number
+  description = "Desired number of worker nodes"
+}
+
+variable "scaling_max_size" {
+  type        = number
+  description = "Maximum number of worker nodes"
+}
+
+variable "scaling_min_size" {
+  type        = number
+  description = "Minimum number of worker nodes"
+}
+
+variable "endpoint_public_access" {
+  type        = bool
+  default     = true
+  description = "Indicates whether or not the Amazon EKS public API server endpoint is enabled."
+}
+
+variable "endpoint_private_access" {
+  type        = bool
+  default     = true
+  description = "Indicates whether or not the Amazon EKS private API server endpoint is enabled."
+}
+
+
+# Network
+variable "vpc_id" {
+  type        = string
+  description = "VPC ID"
+}
+variable "private_subnet_ids" {
+  type        = set(string)
+  description = "Private Subnet IDs"
+}
+variable "public_subnet_ids" {
+  type        = set(string)
+  description = "Public Subnet IDs"
+}
+variable "public_access_cidrs" {
+  type        = set(string)
+  description = "CIDR block range for vpc"
+}
+
+variable "sg_id" {
+  type        = string
+  description = "Cluster Security Group ID"
+}
+
+
+# Roles
+variable "eks_cluster_role_arn" {
+  type        = string
+  description = "Master Cluster Role ARN"
+}
+variable "eks_node_group_role_arn" {
+  type        = string
+  description = "Node Group Cluster Role ARN"
+}

--- a/tf-modules/roles/eks/main.tf
+++ b/tf-modules/roles/eks/main.tf
@@ -1,0 +1,77 @@
+
+# CLUSTER IAM ROLE
+data "aws_iam_policy_document" "eks_cluster_role_policy_document" {
+  statement {
+    sid    = "EKSClusterRolePolicyDocument"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["eks.amazonaws.com"]
+    }
+    actions = [
+      "sts:AssumeRole"
+    ]
+  }
+}
+
+# Create IAM role for Kubernetes clusters to make calls to 
+# other AWS services on your behalf to manage the resources
+# that you use with the service
+resource "aws_iam_role" "eks_cluster_role" {
+  name               = "${var.cluster_name}-eks-cluster-role"
+  assume_role_policy = data.aws_iam_policy_document.eks_cluster_role_policy_document.json
+}
+
+
+#  Attach the EKS-Cluster policies to the master_cluster_role role
+resource "aws_iam_role_policy_attachment" "eks_cluster_role_attachment-AmazonEKSClusterPolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+  role       = aws_iam_role.eks_cluster_role.name
+}
+
+#  Attach the EKS-Service policies to the master_cluster_role role
+resource "aws_iam_role_policy_attachment" "eks_cluster_role_attachment-AmazonEKSServicePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
+  role       = aws_iam_role.eks_cluster_role.name
+}
+
+# NODE GROUP IAM ROLE 
+data "aws_iam_policy_document" "eks_node_group_policy_document" {
+  statement {
+    sid    = "EKSNodesGroupRolePolicyDocument"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+    actions = [
+      "sts:AssumeRole"
+    ]
+  }
+}
+
+# Create IAM role for EKS nodes group to work with other AWS Services
+resource "aws_iam_role" "eks_node_group_role" {
+  name               = "${var.cluster_name}-eks-node-group-role"
+  assume_role_policy = data.aws_iam_policy_document.eks_node_group_policy_document.json
+  force_detach_policies = true
+}
+
+
+#  Attach the AmazonEKSWorkerNodePolicy policies to the eks_node_group_role role
+resource "aws_iam_role_policy_attachment" "eks_node_group_role_attachment-AmazonEKSWorkerNodePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.eks_node_group_role.name
+}
+
+#  Attach the AmazonEKS_CNI_Policy policies to the eks_node_group_role role
+resource "aws_iam_role_policy_attachment" "eks_node_group_role_attachment-AmazonEKS_CNI_Policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.eks_node_group_role.name
+}
+
+#  Attach the AmazonEC2ContainerRegistryReadOnly policies to the eks_node_group_role role
+resource "aws_iam_role_policy_attachment" "eks_node_group_role_attachment-AmazonEC2ContainerRegistryReadOnly" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.eks_node_group_role.name
+}

--- a/tf-modules/roles/eks/output.tf
+++ b/tf-modules/roles/eks/output.tf
@@ -1,0 +1,12 @@
+output "eks_cluster_role_id" {
+  value = aws_iam_role.eks_cluster_role.id
+}
+output "eks_cluster_role_arn" {
+  value = aws_iam_role.eks_cluster_role.arn
+}
+output "eks_node_group_role_id" {
+  value = aws_iam_role.eks_node_group_role.id
+}
+output "eks_node_group_role_arn" {
+  value = aws_iam_role.eks_node_group_role.arn
+}

--- a/tf-modules/roles/eks/variables.tf
+++ b/tf-modules/roles/eks/variables.tf
@@ -1,0 +1,4 @@
+variable "cluster_name" {
+  type        = string
+  description = "Name Of Cluster"
+}

--- a/tf-modules/security_group/eks_default/main.tf
+++ b/tf-modules/security_group/eks_default/main.tf
@@ -1,0 +1,82 @@
+
+# ==== EKS Cluster Security Group ====#
+resource "aws_security_group" "eks_cluster" {
+  name        = "${var.cluster_name}_Public_sg"
+  description = "Security group for Control Plane to allow network traffic to and from the EKS Cluster"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name = "${var.cluster_name}_Public_sg"
+  }
+}
+
+resource "aws_security_group_rule" "cluster_inbound_https" {
+  type                     = "ingress"
+  description              = "Allow Inbound HTTPS Traffic to Control Plane"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.eks_cluster.id
+  source_security_group_id = aws_security_group.nodes.id
+}
+
+resource "aws_security_group_rule" "cluster_inbound_http" {
+  type                     = "ingress"
+  description              = "Allow worker nodes to communicate with the cluster API Server"
+  from_port                = 80
+  to_port                  = 80
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.eks_cluster.id
+  source_security_group_id = aws_security_group.nodes.id
+}
+
+resource "aws_security_group_rule" "cluster_outbound" {
+  type              = "egress"
+  description       = "Allow cluster API Server to communicate with the worker nodes"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  security_group_id = aws_security_group.eks_cluster.id
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+#==== Nodes Security Group ====#
+resource "aws_security_group" "nodes" {
+  name        = "${var.cluster_name}_Nodes_sg"
+  description = "Security group to Allow woker nodes to communicate with each other"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name = "${var.cluster_name}_Nodes_sg"
+  }
+}
+
+resource "aws_security_group_rule" "nodes_inbound_self" {
+  type                     = "ingress"
+  description              = "Allow woker nodes to communicate with each other"
+  from_port                = 0
+  to_port                  = 65535
+  protocol                 = "-1"
+  security_group_id        = aws_security_group.nodes.id
+  source_security_group_id = aws_security_group.nodes.id
+}
+
+resource "aws_security_group_rule" "nodes_inbound_cluster" {
+  type                     = "ingress"
+  description              = "Allow worker nodes to receive communication from the cluster control plane"
+  from_port                = 1025
+  to_port                  = 65535
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.nodes.id
+  source_security_group_id = aws_security_group.eks_cluster.id
+}
+
+resource "aws_security_group_rule" "node_outbound" {
+  type              = "egress"
+  description       = "Allow nodes to communicate outside the cluster"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  security_group_id = aws_security_group.nodes.id
+  cidr_blocks       = ["0.0.0.0/0"]
+}

--- a/tf-modules/security_group/eks_default/output.tf
+++ b/tf-modules/security_group/eks_default/output.tf
@@ -1,0 +1,5 @@
+output "sg_id" {
+  value = aws_security_group.eks_cluster.id
+}
+
+

--- a/tf-modules/security_group/eks_default/variables.tf
+++ b/tf-modules/security_group/eks_default/variables.tf
@@ -10,7 +10,13 @@ variable "stage" {
   type        = string
   description = "Stage"
 }
-variable "ipv4_primary_cidr_block" {
+
+variable "vpc_id" {
   type        = string
-  description = "CIDR Block For VPC"
+  description = "VPC ID"
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "Name of EKS Cluster"
 }

--- a/tf-modules/subnet/output.tf
+++ b/tf-modules/subnet/output.tf
@@ -4,3 +4,12 @@ output "private_subnet_ids" {
 output "public_subnet_ids" {
   value = module.subnet.public_subnet_ids
 }
+output "private_route_table_ids" {
+  value = module.subnet.private_route_table_ids
+}
+output "public_route_table_ids" {
+  value = module.subnet.public_route_table_ids
+}
+output "public_subnet_cidrs" {
+  value = module.subnet.public_subnet_cidrs
+}

--- a/tf-modules/vpc/main.tf
+++ b/tf-modules/vpc/main.tf
@@ -8,6 +8,6 @@ module "vpc" {
   name      = "${var.app_name}-vpc"
 
   internet_gateway_enabled         = true
-  ipv4_primary_cidr_block          = "10.0.0.0/16"
+  ipv4_primary_cidr_block          = var.ipv4_primary_cidr_block
   assign_generated_ipv6_cidr_block = true
 }


### PR DESCRIPTION
Sets up
1. Adds one more Availability Zone for HA 
2. Two availability zones means one more public subnet, one more private subnet, 2 NAT gateways (I can hear my bank account screaming 😬) 
3. VPC: Updated Module so that CIDR Block can be passed in dynamically
4. Subnets: Added output for subnet CIDR block
5. Roles: Added module for 2 new roles; for cluster role and node group role
6. SG: Added module for default security group for cluster control plane and node groups
7. Cluster: Added a module for creating a cluster and node groups from a set of inputs
8. Using all of the above to spin up a small cluster with a control plane and 2 Nodes in AF-South-1 region

Massive Node To: https://niyialimi.medium.com/provisioning-an-aws-kubernetes-cluster-eks-with-terraform-cba435c51517